### PR TITLE
Update __init__.py for HA 2025.6

### DIFF
--- a/custom_components/custom_icons/__init__.py
+++ b/custom_components/custom_icons/__init__.py
@@ -1,27 +1,26 @@
 import logging
+import json
+from os import walk, path
 
 from homeassistant.components.frontend import add_extra_js_url
 from homeassistant.components.http.view import HomeAssistantView
-
-import json
-from os import walk, path
+from homeassistant.components.http import StaticPathConfig  # ✅ Correct import
 
 LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "custom_icons"
-
-DATA_EXTRA_MODULE_URL = 'frontend_extra_module_url'
 LOADER_URL = f'/{DOMAIN}/main.js'
 LOADER_PATH = f'custom_components/{DOMAIN}/main.js'
+
 ICONS_URL = f'/{DOMAIN}/icons'
 ICONLIST_URL = f'/{DOMAIN}/list'
 ICONS_PATH = f'custom_components/{DOMAIN}/data'
+
 CUSTOM_ICONS_URL = f'/{DOMAIN}/icons/pro'
 CUSTOM_ICONS_PATH = 'www/custom_icons/'
 
 
 class ListingView(HomeAssistantView):
-
     requires_auth = False
 
     def __init__(self, url, iconpath):
@@ -31,42 +30,33 @@ class ListingView(HomeAssistantView):
 
     async def get(self, request):
         icons = []
-        for (dirpath, dirnames, filenames) in walk(self.iconpath):
-            icons.extend([{"name": path.join(dirpath[len(self.iconpath):], fn[:-4])} for fn in filenames if fn.endswith(".svg")])
-        return json.dumps(icons)
+        for dirpath, _, filenames in walk(self.iconpath):
+            rel = dirpath[len(self.iconpath):].lstrip(path.sep)
+            icons.extend({"name": path.join(rel, fn[:-4])}
+                         for fn in filenames if fn.endswith(".svg"))
+        return self.json(icons)
 
 
 async def async_setup(hass, config):
-    hass.http.register_static_path(
-            LOADER_URL,
-            hass.config.path(LOADER_PATH),
-            True
-        )
+    static_paths = [
+        StaticPathConfig(LOADER_URL, hass.config.path(LOADER_PATH), True),
+        StaticPathConfig(CUSTOM_ICONS_URL, hass.config.path(CUSTOM_ICONS_PATH), True),
+    ]
+
+    for iset in ["brands", "regular", "solid"]:
+        url = f"{ICONS_URL}/{iset}"
+        dirpath = hass.config.path(f"{ICONS_PATH}/{iset}")
+        static_paths.append(StaticPathConfig(url, dirpath, True))
+        hass.http.register_view(ListingView(f"{ICONLIST_URL}/{iset}", dirpath))
+
+    # Register all static paths at once (async, non-blocking)
+    await hass.http.async_register_static_paths(static_paths)
+
     add_extra_js_url(hass, LOADER_URL)
 
-#     for iset in ["brands", "regular", "solid"]:
-#         hass.http.register_static_path(
-#                 ICONS_URL + "/" + iset,
-#                 hass.config.path(ICONS_PATH + "/" + iset),
-#                 True
-#             )
-#         hass.http.register_view(
-#                 ListingView(
-#                     ICONLIST_URL + "/" + iset,
-#                     hass.config.path(ICONS_PATH + "/" + iset)
-#                 )
-#             )
-    hass.http.register_static_path(
-            CUSTOM_ICONS_URL,
-            hass.config.path(CUSTOM_ICONS_PATH),
-            True
-        )
-    hass.http.register_view(
-            ListingView(
-                ICONLIST_URL + "/pro",
-                hass.config.path(CUSTOM_ICONS_PATH)
-            )
-        )
+    # Add pro icons listing
+    pro_dir = hass.config.path(CUSTOM_ICONS_PATH)
+    hass.http.register_view(ListingView(f"{ICONLIST_URL}/pro", pro_dir))
 
     return True
 


### PR DESCRIPTION
and fit the static_path error:

```
Error during setup of component custom_icons: Detected that custom integration 'custom_icons' calls hass.http.register_static_path which does blocking I/O in the event loop, instead call await hass.http.async_register_static_paths([StaticPathConfig("/custom_icons/main.js", "/config/custom_components/custom_icons/main.js", True)])
```